### PR TITLE
fix: correct device assignment in Backend class

### DIFF
--- a/src/U_stats/_utils/_backend.py
+++ b/src/U_stats/_utils/_backend.py
@@ -68,7 +68,7 @@ class Backend:
                     "cuda" if torch.cuda.is_available() else "cpu"
                 )
             else:
-                self.device = torch.device(self.device)
+                self.device = torch.device(device)
         else:
             self.device = None
 


### PR DESCRIPTION
This pull request includes a small change to the `_init_device` method in `src/U_stats/_utils/_backend.py`. The change ensures that the `device` parameter passed to the method is used directly instead of referencing `self.device`.