### PR TITLE
fix build statu in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![PyPI version](https://badge.fury.io/py/u-stat.svg)](https://badge.fury.io/py/u-stats)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Build Status](https://img.shields.io/github/actions/workflow/status/Amedar-Asterisk/U-Statistics-python/style_check.yml?branch=main)](https://github.com/Amedar-Asterisk/U-Statistics-python/actions)
+[![Style Status](https://img.shields.io/github/actions/workflow/status/Amedar-Asterisk/U-Statistics-python/style_check.yml?branch=main)](https://github.com/Amedar-Asterisk/U-Statistics-python/actions)
 
 **U-statistics** are fundamental tools in statistics, probability theory, theoretical computer science, economics, statistical physics, and machine learning. Named after Wassily Hoeffding, U-statistics provide unbiased estimators for population parameters and form the foundation for many statistical tests and methods. However, computing U-statistics can be computationally demanding, especially for high-order cases where the number of combinations grows exponentially.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![PyPI version](https://badge.fury.io/py/u-stat.svg)](https://badge.fury.io/py/u-stats)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Style Status](https://img.shields.io/github/actions/workflow/status/Amedar-Asterisk/U-Statistics-python/style_check.yml?branch=main)](https://github.com/Amedar-Asterisk/U-Statistics-python/actions)
+[![Style Status](https://img.shields.io/github/actions/workflow/status/Amedar-Asterisk/U-Statistics-python/style_check.yml?branch=main&label=Style)](https://github.com/Amedar-Asterisk/U-Statistics-python/actions)
 
 **U-statistics** are fundamental tools in statistics, probability theory, theoretical computer science, economics, statistical physics, and machine learning. Named after Wassily Hoeffding, U-statistics provide unbiased estimators for population parameters and form the foundation for many statistical tests and methods. However, computing U-statistics can be computationally demanding, especially for high-order cases where the number of combinations grows exponentially.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![PyPI version](https://badge.fury.io/py/u-stat.svg)](https://badge.fury.io/py/u-stats)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Build Status](https://img.shields.io/github/actions/workflow/status/Amedar-Asterisk/U-Statistics-python/ci.yml?branch=main)](https://github.com/Amedar-Asterisk/U-Statistics-python/actions)
+[![Build Status](https://img.shields.io/github/actions/workflow/status/Amedar-Asterisk/U-Statistics-python/style_check.yml?branch=main)](https://github.com/Amedar-Asterisk/U-Statistics-python/actions)
 
 **U-statistics** are fundamental tools in statistics, probability theory, theoretical computer science, economics, statistical physics, and machine learning. Named after Wassily Hoeffding, U-statistics provide unbiased estimators for population parameters and form the foundation for many statistical tests and methods. However, computing U-statistics can be computationally demanding, especially for high-order cases where the number of combinations grows exponentially.
 


### PR DESCRIPTION
This pull request updates the `README.md` file to reflect a change in the GitHub Actions badge. The badge now tracks the status of a style check workflow instead of the CI workflow.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L5-R5): Replaced the "Build Status" badge with a "Style Status" badge, linking to the `style_check.yml` workflow instead of `ci.yml`.